### PR TITLE
Fix wrong spelling in class names of Gallery component

### DIFF
--- a/app/gallery.tsx
+++ b/app/gallery.tsx
@@ -93,13 +93,13 @@ const Gallery = ({ users }: GalleryProps) => {
                   </div>
                   <div className="field">
                     <FaLocationDot className="icon" />
-                    <div className="data">{`${selectedUser.address.street}, ${selectedUser.address.suite}, ${selectedUser.address.city}`}</div>
+                    <div className="value">{`${selectedUser.address.street}, ${selectedUser.address.suite}, ${selectedUser.address.city}`}</div>
                   </div>
                   <div className="field">
                     <FaPhone className="icon" />
                     <div className="value">{selectedUser.phone}</div>
                   </div>
-                  <div className="fields">
+                  <div className="field">
                     <FaEnvelope className="icon" />
                     <div className="value">{selectedUser.email}</div>
                   </div>


### PR DESCRIPTION
### Expected

- Some of the information is not properly aligned with where it should be. Find out what's causing this issue and fix it.
   ![image](https://github.com/gf-co/frontend_test/assets/145439449/b606d380-c4f2-4308-87dc-29cfaca92977)

### Solution

- Fixed misspelled class names.
   ![image](https://github.com/gf-co/frontend_test/assets/145439449/97dc31a5-bd6d-4ce5-bc8f-e9e81c8eb46c)
